### PR TITLE
VQ-3854 - VQ blending issue

### DIFF
--- a/Rendering/VolumeOpenGL2/vtkVolumeStateRAII.h
+++ b/Rendering/VolumeOpenGL2/vtkVolumeStateRAII.h
@@ -126,8 +126,8 @@ class vtkVolumeStateRAII
       }
 
       glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-      //VQ ADDED - is this really needed
-      //glBlendEquation(GL_FUNC_ADD);
+      //Set to what is typically the default blend equation after VQ hijacked it
+      glBlendEquation(GL_FUNC_ADD);
 
       if (!this->BlendEnabled)
       {


### PR DESCRIPTION
So yeah this line was indeed needed.  VTK does not set the blend equation back to GL_FUNC_ADD after VQ hijacks the opengl blending